### PR TITLE
Update jesus.mcfunction

### DIFF
--- a/data/com_anti_hack/functions/hack/jesus.mcfunction
+++ b/data/com_anti_hack/functions/hack/jesus.mcfunction
@@ -3,7 +3,8 @@
 ### Extends com_anti_hack:player/main
 
 tag @s remove coah.jesus
-execute if entity @s[gamemode=!creative,gamemode=!spectator] unless entity @s[nbt={RootVehicle:{Entity:{id:"minecraft:boat"}}}] if block ~ ~-1 ~ water if block ~1 ~-1 ~ water if block ~-1 ~-1 ~ water if block ~ ~-1 ~1 water if block ~ ~-1 ~-1 water if block ~ ~0.1 ~ air run tag @s add coah.jesus
+execute if entity @s[gamemode=!creative,gamemode=!spectator] unless entity @s[nbt={RootVehicle:{Entity:{id:"minecraft:boat"}}}] if block ~ ~-.05 ~ water if block ~1 ~-.05 ~ water if block ~-1 ~-.05 ~ water if block ~ ~-.05 ~1 water if block ~ ~-.05 ~-1 water if block ~ ~0.05 ~ air run tag @s add coah.jesus
 scoreboard players add @s[tag=coah.jesus] coah.t.jesus 1
-execute if score @s coah.t.jesus matches 240.. run function com_anti_hack:admin/notify_jesus
-execute if score @s coah.t.jesus matches 240.. run scoreboard players reset @s coah.t.jesus
+execute if score @s coah.t.jesus matches 1.. if block ~ ~.1 ~ water run scoreboard players remove @s coah.t.jesus 1
+execute if score @s coah.t.jesus matches 120.. run function com_anti_hack:admin/notify_jesus
+execute if score @s coah.t.jesus matches 120.. run scoreboard players reset @s coah.t.jesus


### PR DESCRIPTION
Some changes to make the jesus anti-hack more reliable. Before the changes the anti-hack would think that a player is using jesus just from swimming and not resetting it afterwards. Therefore I made it so that the coah.t.jesus counter will count downwards whenever the player is inside of water to avoid false detections. It would also falsly detect jesus hacks when a player was on top of a boat, shifting out on carpets, slabs, trapdoors, lily pads etc... Therefore I made the block detection more precise. I also changed the detection time to be 6 seconds (120 ticks) instead of 240 ticks. This should be enough because of the changes I did regarding coah.t.jesus