### PR TITLE
Create nofall.mcfunction

### DIFF
--- a/data/com_anti_hack/functions/hack/nofall.mcfunction
+++ b/data/com_anti_hack/functions/hack/nofall.mcfunction
@@ -1,0 +1,12 @@
+# com_anti_hack:hack/nofall
+## Used to detect nofall hacks
+### Extends com_anti_hack:player/main
+
+tag @s remove coah.nofall
+execute store result score @s coah.d.onground run data get entity @s OnGround
+scoreboard players set @s coah.d.inair 0
+execute if block ~ ~-1 ~ air if block ~1 ~-1 ~ air if block ~-1 ~-1 ~ air if block ~ ~-1 ~1 air if block ~ ~-1 ~-1 air if block ~1 ~-1 ~1 air if block ~1 ~-1 ~-1 air if block ~-1 ~-1 ~-1 air if block ~-1 ~-1 ~1 air if block ~ ~ ~ air if block ~1 ~ ~ air if block ~-1 ~ ~ air if block ~ ~ ~1 air if block ~ ~ ~-1 air if block ~1 ~ ~1 air if block ~1 ~ ~-1 air if block ~-1 ~ ~-1 air if block ~-1 ~ ~1 air run scoreboard players set @s coah.d.inair 1
+execute if entity @s[gamemode=!creative,gamemode=!spectator] if score @s coah.d.inair matches 1 if score @s coah.d.onground matches 1 run tag @s add coah.nofall
+scoreboard players add @s[tag=coah.nofall] coah.t.nofall 1
+execute if score @s coah.t.nofall matches 100.. run function com_anti_hack:admin/notify_nofall
+execute if score @s coah.t.nofall matches 100.. run scoreboard players reset @s coah.t.nofall


### PR DESCRIPTION
A nofall anti-hack. When a player is using the nofall hack the "OnGround" tag stays at 1 even when they are in air. Therefore I'm checking if a player actually is in the air and then checking if it still says that they're on the ground. If they are in the air but OnGround at the same time they are using nofall hacks. I'm using a timer of 100 ticks (5 seconds) to make sure that the detection doesn't spam. Since I'm using this method we can even detect if a player who is using NoFall is just jumping a 1 block fall (on ground floor).